### PR TITLE
Alias for reform, change default reform, print dataframe

### DIFF
--- a/openfisca_plugin_aggregates/tests/test_aggregates.py
+++ b/openfisca_plugin_aggregates/tests/test_aggregates.py
@@ -54,3 +54,4 @@ if __name__ == '__main__':
     import sys
     logging.basicConfig(level = logging.INFO, stream = sys.stdout)
     df = test_aggregates()
+    print df

--- a/openfisca_plugin_aggregates/tests/test_aggregates_reform.py
+++ b/openfisca_plugin_aggregates/tests/test_aggregates_reform.py
@@ -58,11 +58,13 @@ def test_aggregates_reform(data_year = 2009, year = 2013, reform = None):
 
 
 if __name__ == '__main__':
-    from openfisca_france.reforms import plf2015
-    reform = plf2015.build_reform(base.france_data_tax_benefit_system)
+    from openfisca_france.reforms import allocations_familiales_imposables as reform_to_test
+    reform = reform_to_test.build_reform(base.france_data_tax_benefit_system)
 
     import logging
     log = logging.getLogger(__name__)
     import sys
     logging.basicConfig(level = logging.INFO, stream = sys.stdout)
     aggregates, base_data_frame = test_aggregates_reform(data_year = 2009, year = 2013, reform = reform)
+
+    print aggregates, base_data_frame


### PR DESCRIPTION
Alias for the reform such that it is a slightly bit more general
Change default reform for one that is currently working
print result such that user see dataframes when running the script
